### PR TITLE
Added function for detecting message lang

### DIFF
--- a/detect_lang/detect_lang.py
+++ b/detect_lang/detect_lang.py
@@ -1,0 +1,17 @@
+from langdetect import DetectorFactory, detect
+
+# ensures consistent probabilities from detect() method
+DetectorFactory.seed = 0
+
+def get_message_lang(message_text, user_target_lang, user_native_lang):
+    if detect(message_text) == user_target_lang:
+        return user_target_lang
+    elif detect(message_text) == user_native_lang:
+        return user_native_lang
+    else:
+        # Currently if a message has a number of spelling errors, the langdetect
+        # library will possibly misidentify the language; i.e. "Helo Woorld"
+        # will be misidentified as Dutch, rather than English. Returning the
+        # entered message in this situation is just a placeholder until this
+        # issue is resolved.
+        return message_text


### PR DESCRIPTION
I went ahead and made a basic function for detecting the language of a message, in order to identify it as either being typed in the user's target language (so it can be seen by other users) or native language (so it can be ignored). 

I did run into an issue concerning the langdetect library; due to the nature of the library's probability-based algorithm, it will occasionally misidentify a message's language if the message contains spelling errors. For example, "Hello World!" will return English, while "Helo Woorld!" will return Dutch. I could use some help coming up with a solution for this problem.